### PR TITLE
Added config option to select Websocket protocol (ws:// or wss://)

### DIFF
--- a/lang/en/vpl.php
+++ b/lang/en/vpl.php
@@ -240,6 +240,11 @@ $string['vpl_evaluate.sh'] = 'This script prepares the evaluation';
 $string['vpl_run.sh'] = 'This script prepares the execution';
 $string['workingperiods'] = 'Working periods';
 $string['worktype']='Type of work';
+$string['websocket_protocol'] = 'WebSocket protocol';
+$string['websocket_protocol_description'] = 'Type of WebSocket protocol (ws:// or wss://) used by the browser to connect to execution servers.';
+$string['always_use_wss'] = 'Always use secure (wss) websocket protocol';
+$string['always_use_ws'] = 'Always use unsecure (ws) websocket protocol';
+$string['depends_on_https'] = 'Use wss or ws depending on https header';
 
 $string['check_jail_servers_help'] = <<<'END_OF_HELP'
 <p>This page check and show the status of execution servers used

--- a/settings.php
+++ b/settings.php
@@ -68,6 +68,14 @@ $settings->add(new admin_setting_configtextarea('vpl_jail_servers',
                get_string('jail_servers', VPL),get_string('jail_servers_description', VPL),$default));
 $settings->add(new admin_setting_configcheckbox('vpl_acceptcertificates', get_string('acceptcertificates', VPL),
                        get_string('acceptcertificates_description', VPL), 1));
+
+$ws_options = array('always_use_wss' => get_string('always_use_wss', VPL),
+                    'always_use_ws' => get_string('always_use_ws', VPL),
+                    'depends_on_https' => get_string('depends_on_https', VPL));
+$settings->add(new admin_setting_configselect('vpl_websocket_protocol',
+               get_string('websocket_protocol', VPL),
+               get_string('websocket_protocol_description', VPL), 'depends_on_https', $ws_options));
+
 $settings->add(new admin_setting_heading('heading3','',get_string('miscellaneous')));
 $list = vpl_get_select_time();
 $default = vpl_get_array_key($list,60);

--- a/vpl_submission_CE.class.php
+++ b/vpl_submission_CE.class.php
@@ -319,10 +319,11 @@ class mod_vpl_submission_CE extends mod_vpl_submission{
 		$jailResponse = $this->jailRequestAction($data,$maxmemory,$localservers,$server);
 		$isHTTPS = isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on";
 		$parsed = parse_url($server);
-		if($isHTTPS)
-			$baseURL = 'wss://';
-		else
-			$baseURL = 'ws://';
+        	switch($CFG->vpl_websocket_protocol) {
+	            case 'always_use_wss': $baseURL = 'wss://'; break;
+        	    case 'always_use_ws': $baseURL = 'ws://'; break;
+	            default: $baseURL = $isHTTPS ? 'wss://' : 'ws://';
+        	}
 		$baseURL.=$parsed['host'];
 		if($isHTTPS)
 			$baseURL.=':'.$jailResponse['secureport'];


### PR DESCRIPTION
Hi there,

We at the Federal University of Santa Catarina were having some problems with websocket connections from our clients: although we use https, the websocket connections were being made using ws:// instead of wss://.
Investigating the issue, we verified that the sole use of $isHTTPS in the "vpl_submission_CE.class.php" file was not enough to correctly determine the type of websocket protocol to use in our case (our servers are behind a proxy; the connection from the clients to the proxy are made using https, and the connections behind the proxy use http).

We created an additional option to select which protocol must be used to solve our problem. If none is selected, the default behavior is to consider $isHTTPS.

Thanks!