### PR TITLE
Fix "cat: VPL_SUBFILE0: No such file or directory"

### DIFF
--- a/jail/default_scripts/shell_run.sh
+++ b/jail/default_scripts/shell_run.sh
@@ -8,5 +8,5 @@
 #load common script and check programs
 . common_script.sh
 cat common_script.sh > vpl_execution
-cat VPL_SUBFILE0 >> vpl_execution
+cat $VPL_SUBFILE0 >> vpl_execution
 chmod +x vpl_execution


### PR DESCRIPTION
Missing $ prevents running .sh scripts with the default configuration