### PR TITLE
Fixed german lang string for download submissions

### DIFF
--- a/lang/de/vpl.php
+++ b/lang/de/vpl.php
@@ -151,7 +151,8 @@ $string ['inconsistentgroup'] = 'Sie sind nicht Mitglied nur einer Gruppe (0 o >
 $string ['worktype'] = 'Arbeitstyp';
 $string ['individualwork'] = 'Einzelarbeit';
 $string ['groupwork'] = 'Gruppenarbeit';
-$string ['downloadsubmissions'] = 'Alle Abgaben herunterladen';
+$string ['downloadallsubmissions'] = 'Alle Abgaben herunterladen';
+$string ['downloadsubmissions'] = 'Abgaben herunterladen';
 
 $string ['similarity'] = 'Ähnlichkeit';
 $string ['listwatermarks'] = 'Wasserzeichen-Liste';


### PR DESCRIPTION
The previous value of the German lang string for "downloadsubmissions" meant "Download all submissions" whereas that should be the value for "downloadallsubmissions".

The strings for other languages may also contain this error.