### PR TITLE
Fix activity settings menu not being shown in description page

### DIFF
--- a/view.php
+++ b/view.php
@@ -45,6 +45,10 @@ if (! $vpl->has_capability( VPL_MANAGE_CAPABILITY ) && ! $vpl->has_capability( V
     $userid = $USER->id;
 } else {
     $userid = optional_param( 'userid', $USER->id, PARAM_INT );
+    $vpl->prepare_page( 'view.php', array (
+            'id' => $id,
+            'userid' => $userid
+    ) );
 }
 
 \mod_vpl\event\vpl_description_viewed::log( $vpl );


### PR DESCRIPTION
The problem seems to be that the GET parameter "userid" is not passed when calling `$PAGE->set_url()`. Maybe there is a cleaner solution, but this works.

Fixes #90 