### PR TITLE
Updated Java jail scripts to not throw an error on missing jar files

### DIFF
--- a/jail/default_scripts/java_debug.sh
+++ b/jail/default_scripts/java_debug.sh
@@ -30,7 +30,7 @@ JUNIT4=/usr/share/java/junit4.jar
 if [ -f $JUNIT4 ] ; then
 	CLASSPATH=$CLASSPATH:$JUNIT4
 fi
-get_source_files jar
+get_source_files jar NOERROR
 for JARFILE in $SOURCE_FILES
 do
 	CLASSPATH=$CLASSPATH:$JARFILE

--- a/jail/default_scripts/java_run.sh
+++ b/jail/default_scripts/java_run.sh
@@ -44,7 +44,7 @@ JUNIT4=/usr/share/java/junit4.jar
 if [ -f $JUNIT4 ] ; then
 	CLASSPATH=$CLASSPATH:$JUNIT4
 fi
-get_source_files jar
+get_source_files jar NOERROR
 for JARFILE in $SOURCE_FILES
 do
 	CLASSPATH=$CLASSPATH:$JARFILE


### PR DESCRIPTION
Added NOERROR to the `get_source_files` call for .jar files.