### PR TITLE
V3.4dev Fix for issue #106

### DIFF
--- a/similarity/similarity_base.class.php
+++ b/similarity/similarity_base.class.php
@@ -221,6 +221,10 @@ class vpl_similarity_base {
         $dif += $other->get_sizeh() - $taken;
         return 100 * (1 - ($dif / ($this->sizeh + $other->get_sizeh())));
     }
+
+    static public function clone_token($token, $value){
+        return new vpl_token($token->type, $value, $token->line);
+    }
 }
 
 // TODO refactor to a protected class.

--- a/similarity/similarity_c.class.php
+++ b/similarity/similarity_c.class.php
@@ -78,50 +78,43 @@ class vpl_similarity_c extends vpl_similarity_base {
                         $posiniinst = count( $ret );
                         break;
                     case '++' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '+';
                         $ret [] = $token;
                         break;
                     case '--' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '-';
                         $ret [] = $token;
                         break;
                     case '+=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '+';
                         $ret [] = $token;
                         break;
                     case '-=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '-';
                         $ret [] = $token;
                         break;
                     case '*=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '*';
                         $ret [] = $token;
                         break;
                     case '/=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '/';
                         $ret [] = $token;
                         break;
                     case '%=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         self::expand_operator( $ret, $posiniinst );
                         $token->value = '%';
                         $ret [] = $token;
@@ -130,12 +123,9 @@ class vpl_similarity_c extends vpl_similarity_base {
                         if ($prev->value == 'this') {
                             break;
                         }
-                        $token->value = '(';
-                        $ret [] = $token;
-                        $token->value = '*';
-                        $ret [] = $token;
-                        $token->value = ')';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '(');
+                        $ret [] = self::clone_token($token, '*');
+                        $ret [] = self::clone_token($token, ')');
                         $token->value = '.';
                         $ret [] = $token;
                         break;

--- a/similarity/similarity_java.class.php
+++ b/similarity/similarity_java.class.php
@@ -67,44 +67,37 @@ class vpl_similarity_java extends vpl_similarity_c {
                         $ret [] = $token;
                         break;
                     case '++' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '+';
                         $ret [] = $token;
                         break;
                     case '--' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '-';
                         $ret [] = $token;
                         break;
                     case '+=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '+';
                         $ret [] = $token;
                         break;
                     case '-=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '-';
                         $ret [] = $token;
                         break;
                     case '*=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '*';
                         $ret [] = $token;
                         break;
                     case '/=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '/';
                         $ret [] = $token;
                         break;
                     case '%=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '%';
                         $ret [] = $token;
                         break;

--- a/similarity/similarity_python.class.php
+++ b/similarity/similarity_python.class.php
@@ -49,38 +49,32 @@ class vpl_similarity_python extends vpl_similarity_base {
                         // Ignore semicolon.
                         break;
                     case '+=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '+';
                         $ret [] = $token;
                         break;
                     case '-=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '-';
                         $ret [] = $token;
                         break;
                     case '*=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '*';
                         $ret [] = $token;
                         break;
                     case '/=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '/';
                         $ret [] = $token;
                         break;
                     case '//=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '//';
                         $ret [] = $token;
                         break;
                     case '%=' :
-                        $token->value = '=';
-                        $ret [] = $token;
+                        $ret [] = self::clone_token($token, '=');
                         $token->value = '%';
                         $ret [] = $token;
                         break;


### PR DESCRIPTION
Fixes certain situations where tokens should be cloned, rather than reassigned as reported through #106.

Can be painlessly rebased/cherrypicked on top of the v3.3.7 branch if needed for a v3.3.8 release.