### PR TITLE
Added override options for some settings (due date, etc.). (See issue #83)

### DIFF
--- a/backup/moodle2/backup_vpl_stepslib.php
+++ b/backup/moodle2/backup_vpl_stepslib.php
@@ -211,6 +211,27 @@ class backup_vpl_activity_structure_step extends backup_activity_structure_step 
     );
 
     /**
+     * @var array Overrides table fields list
+     */
+    protected $overridefields = array (
+            'vpl',
+            'startdate',
+            'duedate',
+            'freeevaluations',
+            'reductionbyevaluation'
+    );
+
+    /**
+     * @var array Assigned Overrides table fields list
+     */
+    protected $assioverridefields = array (
+            'vpl',
+            'userid',
+            'groupid',
+            'override'
+    );
+
+    /**
      * Define the full structure of a VPL instance with user data
      * {@inheritDoc}
      * @see backup_structure_step::define_structure()
@@ -235,6 +256,12 @@ class backup_vpl_activity_structure_step extends backup_activity_structure_step 
         $asignedvariation = new backup_nested_element( 'asigned_variation',
                 $idfield,
                 $this->asivariationfields );
+        $overrides = new backup_nested_element( 'overrides' );
+        $override = new backup_nested_element( 'override', $idfield, $this->overridefields );
+        $assignedoverrides = new backup_nested_element( 'assigned_overrides' );
+        $assignedoverride = new backup_nested_element( 'assigned_override',
+                $idfield,
+                $this->assioverridefields );
         $submissions = new backup_nested_element( 'submissions' );
         $submission = new backup_nested_element( 'submission', $idfield, $this->submissionfields );
         $submissionfiles = new backup_nested_element( 'submission_files' );
@@ -243,12 +270,16 @@ class backup_vpl_activity_structure_step extends backup_activity_structure_step 
         $vpl->add_child( $requiredfiles );
         $vpl->add_child( $executionfiles );
         $vpl->add_child( $variations );
+        $vpl->add_child( $overrides );
+        $vpl->add_child( $assignedoverrides );
         $vpl->add_child( $submissions );
         $requiredfiles->add_child( $requiredfile );
         $executionfiles->add_child( $executionfile );
         $variations->add_child( $variation );
         $variation->add_child( $asignedvariations );
         $asignedvariations->add_child( $asignedvariation );
+        $overrides->add_child( $override );
+        $assignedoverrides->add_child( $assignedoverride );
         $submissions->add_child( $submission );
         $submission->add_child( $submissionfiles );
         $submissionfiles->add_child( $submissionfile );
@@ -261,8 +292,10 @@ class backup_vpl_activity_structure_step extends backup_activity_structure_step 
         $query .= '   WHERE s.id = ?';
         $vpl->set_source_sql( $query, array ( backup::VAR_ACTIVITYID ) );
         $variation->set_source_table( 'vpl_variations', $parmvplid );
+        $override->set_source_table( 'vpl_overrides', $parmvplid );
         if ($userinfo) {
             $asignedvariation->set_source_table( 'vpl_assigned_variations', $parmvplid );
+            $assignedoverride->set_source_table( 'vpl_assigned_overrides', $parmvplid );
             /*
              * Uncomment next line and comment nexts to backup all student's submissions, not only last one.
              * $submission->set_source_table('vpl_submissions', $parmvplid);
@@ -279,6 +312,8 @@ class backup_vpl_activity_structure_step extends backup_activity_structure_step 
         $vpl->annotate_ids( 'scale', 'grade' );
         $vpl->annotate_ids( 'vpl', 'basedon' );
         $asignedvariation->annotate_ids( 'user', 'userid' );
+        $assignedoverride->annotate_ids( 'user', 'userid' );
+        $assignedoverride->annotate_ids( 'group', 'groupid' );
         $submission->annotate_ids( 'user', 'userid' );
         $submission->annotate_ids( 'user', 'grader' );
         $submission->annotate_ids( 'group', 'groupid' );

--- a/classes/event/override_base.php
+++ b/classes/event/override_base.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of VPL for Moodle - http://vpl.dis.ulpgc.es/
+//
+// VPL for Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// VPL for Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with VPL for Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class for logging of override updated events
+ *
+ * @package mod_vpl
+ * @copyright 2014 onwards Juan Carlos Rodríguez-del-Pino, 2021 Astor Bizard
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_vpl\event;
+
+defined( 'MOODLE_INTERNAL' ) || die();
+require_once(dirname( __FILE__ ) . '/../../locallib.php');
+class override_base extends base {
+    public static function get_objectid_mapping() {
+        return array('db' => VPL_OVERRIDES, 'restore' => VPL_OVERRIDES);
+    }
+    public static function get_other_mapping() {
+        // Nothing to map.
+        return false;
+    }
+    protected function init() {
+        $this->data ['crud'] = 'u';
+        $this->data ['edulevel'] = self::LEVEL_TEACHING;
+        $this->data ['objecttable'] = VPL_OVERRIDES;
+    }
+    public static function log($vpl, $overrideid = null) {
+        if (is_array($vpl)) {
+            $info = $vpl;
+        } else {
+            $vplinstance = $vpl->get_instance();
+            $info = array (
+                    'objectid' => $overrideid,
+                    'contextid' => $vpl->get_context()->id,
+                    'courseid' => $vplinstance->course,
+                    'other' => array('vplid' => $vplinstance->id),
+            );
+        }
+        parent::log( $info );
+    }
+    public function get_url() {
+        return $this->get_url_base( 'view.php' );
+    }
+    public function get_description_mod($mod) {
+        $desc = 'The user with id ' . $this->userid . ' ' . $mod;
+        $desc .= ' override with id ' . $this->objectid . ' of VPL activity with id ' . $this->other['vplid'];
+        if ($this->relateduserid) {
+            $desc .= ' for user with id ' . $this->relateduserid;
+        }
+        return $desc;
+    }
+}

--- a/classes/event/override_created.php
+++ b/classes/event/override_created.php
@@ -15,23 +15,23 @@
 // along with VPL for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version config
+ * Class for logging of override created events
  *
- * @package mod_vpl.
- * @copyright 2021 Juan Carlos Rodríguez-del-Pino
+ * @package mod_vpl
+ * @copyright 2014 onwards Juan Carlos Rodríguez-del-Pino, 2021 Astor Bizard
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
- *
- * Define the plugin global var attributes.
- * @var object $plugin
  */
+namespace mod_vpl\event;
 
-
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version = 2021061600;
-$plugin->requires = 2018051713; // Moodle 3.5!
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.4.3';
-
-$plugin->component = 'mod_vpl';
+defined( 'MOODLE_INTERNAL' ) || die();
+require_once(dirname( __FILE__ ) . '/../../locallib.php');
+class override_created extends override_base {
+    protected function init() {
+        parent::init();
+        $this->data ['crud'] = 'c';
+        $this->legacyaction = 'created override';
+    }
+    public function get_description() {
+        return $this->get_description_mod( 'created' );
+    }
+}

--- a/classes/event/override_deleted.php
+++ b/classes/event/override_deleted.php
@@ -15,23 +15,23 @@
 // along with VPL for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version config
+ * Class for logging of override deleted events
  *
- * @package mod_vpl.
- * @copyright 2021 Juan Carlos Rodríguez-del-Pino
+ * @package mod_vpl
+ * @copyright 2014 onwards Juan Carlos Rodríguez-del-Pino, 2021 Astor Bizard
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
- *
- * Define the plugin global var attributes.
- * @var object $plugin
  */
-
+namespace mod_vpl\event;
 
 defined('MOODLE_INTERNAL') || die();
-
-$plugin->version = 2021061600;
-$plugin->requires = 2018051713; // Moodle 3.5!
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.4.3';
-
-$plugin->component = 'mod_vpl';
+require_once(dirname(__FILE__).'/../../locallib.php');
+class override_deleted extends override_base {
+    protected function init() {
+        parent::init();
+        $this->data['crud'] = 'd';
+        $this->legacyaction = 'deleted override';
+    }
+    public function get_description() {
+        return $this->get_description_mod( 'deleted' );
+    }
+}

--- a/classes/event/override_updated.php
+++ b/classes/event/override_updated.php
@@ -15,23 +15,23 @@
 // along with VPL for Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version config
+ * Class for logging of override updated events
  *
- * @package mod_vpl.
- * @copyright 2021 Juan Carlos Rodríguez-del-Pino
+ * @package mod_vpl
+ * @copyright 2014 onwards Juan Carlos Rodríguez-del-Pino, 2021 Astor Bizard
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
- *
- * Define the plugin global var attributes.
- * @var object $plugin
  */
+namespace mod_vpl\event;
 
-
-defined('MOODLE_INTERNAL') || die();
-
-$plugin->version = 2021061600;
-$plugin->requires = 2018051713; // Moodle 3.5!
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.4.3';
-
-$plugin->component = 'mod_vpl';
+defined( 'MOODLE_INTERNAL' ) || die();
+require_once(dirname( __FILE__ ) . '/../../locallib.php');
+class override_updated extends override_base {
+    protected function init() {
+        parent::init();
+        $this->data ['crud'] = 'u';
+        $this->legacyaction = 'updated override';
+    }
+    public function get_description() {
+        return $this->get_description_mod( 'updated' );
+    }
+}

--- a/css/overrides.css
+++ b/css/overrides.css
@@ -1,0 +1,19 @@
+.path-mod-vpl .override-option .col-md-3 {
+    height: 0;
+}
+
+.path-mod-vpl .override-option .fdate_time_selector div:nth-child(3) {
+    break-after: always;
+}
+
+.path-mod-vpl .override-option > .form-group:first-child {
+    margin-bottom: 0;
+}
+
+.path-mod-vpl #vpl_override_options_form #fgroup_id_buttonar {
+    display: none;
+}
+
+.path-mod-vpl .override-action-button {
+    cursor: pointer;
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/vpl/db" VERSION="20201227" COMMENT="XMLDB file for Moodle mod/vpl"
+<XMLDB PATH="mod/vpl/db" VERSION="20210616" COMMENT="XMLDB file for Moodle mod/vpl"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -137,6 +137,38 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="userid_id" UNIQUE="true" FIELDS="userid, id" COMMENT="Index for userid id"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="vpl_overrides" COMMENT="Overrides to VPL settings">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="vpl" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="VPL id"/>
+        <FIELD NAME="startdate" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If set, date the vpl will be available"/>
+        <FIELD NAME="duedate" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If set, after this date this vpl instance will not be available"/>
+        <FIELD NAME="freeevaluations" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If set, number of automatic evaluations that do not reduce final score"/>
+        <FIELD NAME="reductionbyevaluation" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If set, reduce final score by a value or percentage for each automatic evaluation"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="vpl" UNIQUE="false" FIELDS="vpl"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="vpl_assigned_overrides" COMMENT="Overrides assignations to users and groups">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="vpl" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="VPL id"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="User this override applies to"/>
+        <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Group this override applies to"/>
+        <FIELD NAME="override" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Override id"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="vpl" UNIQUE="false" FIELDS="vpl"/>
+        <INDEX NAME="override" UNIQUE="false" FIELDS="override"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -378,6 +378,61 @@ function xmldb_vpl_upgrade_2021011014() {
 }
 
 /**
+ * Upgrades VPL to 2021061600 version (overrides).
+ *
+ * @return void
+ */
+function xmldb_vpl_upgrade_2021061600() {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    // Define table vpl_overrides to be created.
+    $table = new xmldb_table('vpl_overrides');
+
+    // Adding fields to table vpl_overrides.
+    $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+    $table->add_field('vpl', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('startdate', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('duedate', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('freeevaluations', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('reductionbyevaluation', XMLDB_TYPE_CHAR, '10', null, null, null, null);
+
+    // Adding keys to table vpl_overrides.
+    $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+    // Adding indexes to table vpl_assigned_overrides.
+    $table->add_index('vpl', XMLDB_INDEX_NOTUNIQUE, ['vpl']);
+
+    // Conditionally launch create table for vpl_overrides.
+    if (!$dbman->table_exists($table)) {
+        $dbman->create_table($table);
+    }
+
+    // Define table vpl_assigned_overrides to be created.
+    $table = new xmldb_table('vpl_assigned_overrides');
+
+    // Adding fields to table vpl_assigned_overrides.
+    $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+    $table->add_field('vpl', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('groupid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+    $table->add_field('override', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+    // Adding keys to table vpl_assigned_overrides.
+    $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+    // Adding indexes to table vpl_assigned_overrides.
+    $table->add_index('vpl', XMLDB_INDEX_NOTUNIQUE, ['vpl']);
+    $table->add_index('override', XMLDB_INDEX_NOTUNIQUE, ['override']);
+
+    // Conditionally launch create table for vpl_assigned_overrides.
+    if (!$dbman->table_exists($table)) {
+        $dbman->create_table($table);
+    }
+}
+
+/**
  * Upgrades VPL DB and data to the new version
  *
  * @param int $oldversion Current version
@@ -415,6 +470,11 @@ function xmldb_vpl_upgrade($oldversion = 0) {
     if ($oldversion < $vpl34) {
         xmldb_vpl_upgrade_2021011014();
         upgrade_mod_savepoint(true, $vpl34, 'vpl');
+    }
+
+    if ($oldversion < 2021061600) {
+        xmldb_vpl_upgrade_2021061600();
+        upgrade_mod_savepoint(true, 2021061600, 'vpl');
     }
     return true;
 }

--- a/forms/edit.class.php
+++ b/forms/edit.class.php
@@ -189,9 +189,8 @@ class mod_vpl_edit{
             $files = self::get_requested_files( $vpl );
             $compilationexecution = new stdClass();
             $compilationexecution->nevaluations = 0;
-            $vplinstance = $vpl->get_instance();
-            $compilationexecution->freeevaluations = $vplinstance->freeevaluations;
-            $compilationexecution->reductionbyevaluation = $vplinstance->reductionbyevaluation;
+            $compilationexecution->freeevaluations = $vpl->get_effective_setting('freeevaluations', $userid);
+            $compilationexecution->reductionbyevaluation = $vpl->get_effective_setting('reductionbyevaluation', $userid);
 
         }
         return $files;
@@ -236,8 +235,8 @@ class mod_vpl_edit{
             $compilationexecution = new stdClass();
             $compilationexecution->grade = '';
             $compilationexecution->nevaluations = 0;
-            $compilationexecution->freeevaluations = $vplinstance->freeevaluations;
-            $compilationexecution->reductionbyevaluation = $vplinstance->reductionbyevaluation;
+            $compilationexecution->freeevaluations = $vpl->get_effective_setting('freeevaluations', $userid);
+            $compilationexecution->reductionbyevaluation = $vpl->get_effective_setting('reductionbyevaluation', $userid);
             $response->compilationexecution = $compilationexecution;
         }
         return $response;

--- a/forms/edit.json.php
+++ b/forms/edit.json.php
@@ -129,9 +129,10 @@ try {
         default:
             throw new Exception( 'ajax action error: ' + $action );
     }
-    $timeleft = $instance->duedate - time();
+    $duedate = $vpl->get_effective_setting('duedate', $userid);
+    $timeleft = $duedate - time();
     $hour = 60 * 60;
-    if ( $instance->duedate > 0 && $timeleft > -$hour ) {
+    if ( $duedate > 0 && $timeleft > -$hour ) {
         $result->response->timeLeft = $timeleft;
     }
 } catch ( Exception $e ) {

--- a/forms/edit.php
+++ b/forms/edit.php
@@ -98,9 +98,10 @@ if ( $copy ) {
     $options['loadajaxurl'] = $loadajaxurl . '&action=';
 }
 $options['download'] = "../views/downloadsubmission.php?id={$id}&userid={$linkuserid}";
-$timeleft = $instance->duedate - time();
+$duedate = $vpl->get_effective_setting('duedate', $linkuserid);
+$timeleft = $duedate - time();
 $hour = 60 * 60;
-if ( $instance->duedate > 0 && $timeleft > -$hour ) {
+if ( $duedate > 0 && $timeleft > -$hour ) {
     $options['timeLeft'] = $timeleft;
 }
 if ( $subid ) {

--- a/forms/overrides.php
+++ b/forms/overrides.php
@@ -1,0 +1,442 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Override definitions form
+ *
+ * @package mod_vpl
+ * @copyright 2021 Astor Bizard
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+require_once(__DIR__ . '/../locallib.php');
+require_once(__DIR__ . '/../vpl.class.php');
+global $CFG;
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Return HTML fragment for buttons of a given override row.
+ * @param int $id VPL cmid.
+ * @param int $overrideid Override id for the current row.
+ * @param int $editing The id of the override being edited.
+ * @return string HTML fragment for buttons.
+ */
+function vpl_get_overrideactions($id, $overrideid, $editing) {
+    global $OUTPUT, $PAGE;
+    if ($editing == $overrideid) {
+        vpl_include_jsfile('override.js');
+        $save = '<span class="btn-link override-action-button" onclick="VPL.submitOverrideForms();">' .
+                    $OUTPUT->pix_icon( 'save', get_string('save'), 'mod_vpl' ) .
+                '</span>';
+        $cancel = '<span class="btn-link override-action-button" onclick="VPL.cancelOverrideForms();">' .
+                    $OUTPUT->pix_icon( 'cancel', get_string('cancel'), 'mod_vpl' ) .
+                '</span>';
+        return $save . $cancel;
+    } else if ($editing === null) {
+        $edit = '<a href="?id=' . $id . '&edit=' . $overrideid . '">' .
+                    $OUTPUT->pix_icon( 'editthis', get_string('edit'), 'mod_vpl' ) .
+                '</a>';
+        $deletebuttonid = 'delete_override_' . $overrideid;
+        $delete = '<a id="' . $deletebuttonid . '" href="?id=' . $id . '&delete=' . $overrideid . '">' .
+                      $OUTPUT->pix_icon( 'delete', get_string('delete'), 'mod_vpl' ) .
+                  '</a>';
+        $PAGE->requires->event_handler('#' . $deletebuttonid, 'click', 'M.util.show_confirm_dialog',
+                array('message' => get_string('confirmoverridedeletion', VPL)));
+        return $edit . $delete;
+    } else {
+        return '';
+    }
+}
+
+class vpl_override_users_form extends moodleform {
+    protected $users;
+    protected $groups;
+    public function __construct($users, $groups) {
+        $this->users = $users;
+        $this->groups = $groups;
+        parent::__construct();
+        $this->_form->updateAttributes(array('id' => 'vpl_override_users_form'));
+    }
+    protected function definition() {
+        global $CFG;
+        $mform = &$this->_form;
+        foreach (array('users', 'groups') as $field) {
+            if ($this->$field !== null) {
+                $mform->addElement('html', '<div>');
+                $mform->addElement('autocomplete', $field, get_string($field), $this->$field, array('multiple' => true));
+                $mform->addElement('html', '</div>');
+            }
+        }
+    }
+}
+
+class vpl_override_options_form extends moodleform {
+    protected $id;
+    protected $overrideid;
+    public function __construct($id, $overrideid) {
+        $this->id = $id;
+        $this->overrideid = $overrideid;
+        parent::__construct();
+        $this->_form->updateAttributes(array('id' => 'vpl_override_options_form'));
+    }
+    protected function definition() {
+        $mform = &$this->_form;
+        $mform->addElement('hidden', 'id', $this->id);
+        $mform->setType('id', PARAM_RAW);
+        $mform->addElement('hidden', 'update', $this->overrideid);
+        $mform->setType('update', PARAM_RAW);
+        $mform->addElement('hidden', 'edit', $this->overrideid);
+        $mform->setType('edit', PARAM_RAW);
+        $mform->addElement('hidden', 'userids');
+        $mform->setType('userids', PARAM_RAW);
+        $mform->addElement('hidden', 'groupids');
+        $mform->setType('groupids', PARAM_RAW);
+
+        foreach (array('startdate', 'duedate') as $datefield) {
+            $mform->addElement('html', '<div class="override-option">');
+            $mform->addElement('checkbox', 'override_' . $datefield, get_string( $datefield, VPL ), get_string( 'override', VPL ));
+            $mform->addHelpButton('override_' . $datefield, 'override', VPL);
+            $mform->addElement('date_time_selector', $datefield, null, array('optional' => true));
+            $mform->disabledIf($datefield, 'override_' . $datefield);
+            $mform->addElement('html', '</div>');
+        }
+
+        foreach (array('reductionbyevaluation', 'freeevaluations') as $textfield) {
+            $mform->addElement('html', '<div class="override-option">');
+            $mform->addElement('checkbox', 'override_' . $textfield, get_string( $textfield, VPL ), get_string( 'override', VPL ));
+            $mform->addHelpButton('override_' . $textfield, 'override', VPL);
+            $mform->addElement('text', $textfield, null);
+            $mform->setType($textfield, PARAM_TEXT);
+            $mform->setDefault($textfield, 0);
+            $mform->disabledIf($textfield, 'override_' . $textfield);
+            $mform->addElement('html', '</div>');
+        }
+
+        $this->add_action_buttons();
+    }
+
+    public static function validate($field, $pattern, $message, & $data, & $errors) {
+        $data[$field] = trim( $data[$field] );
+        $res = preg_match($pattern, $data[$field]);
+        if ( $res == 0 || $res == false) {
+            $errors[$field] = $message;
+        }
+    }
+
+    public function validation($data, $files) {
+        $errors = parent::validation($data, $files);
+        self::validate('freeevaluations', '/^[0-9]*$/', '[0..]', $data, $errors);
+        self::validate('reductionbyevaluation', '/^[0-9]*(\.[0-9]+)?%?$/', '#[.#][%]', $data, $errors);
+        return $errors;
+    }
+}
+
+require_login();
+
+global $PAGE, $OUTPUT, $DB;
+
+$id = required_param( 'id', PARAM_INT );
+$edit = optional_param('edit', null, PARAM_INT);
+$delete = optional_param('delete', null, PARAM_INT);
+$update = optional_param('update', null, PARAM_INT);
+$vpl = new mod_vpl( $id );
+$vpl->require_capability( VPL_MANAGE_CAPABILITY );
+$vpl->prepare_page( 'forms/overrides.php', array( 'id' => $id ) );
+
+$vplid = $vpl->get_instance()->id;
+
+$sql = 'SELECT o.*, GROUP_CONCAT(ao.userid) as userids, GROUP_CONCAT(ao.groupid) as groupids
+            FROM {vpl_overrides} o
+            LEFT JOIN {vpl_assigned_overrides} ao ON ao.override = o.id
+            WHERE o.vpl = :vplid
+            GROUP BY o.id
+            ORDER BY o.id ASC';
+$overrides = $DB->get_records_sql($sql, array('vplid' => $vplid));
+
+$fields = array('startdate', 'duedate', 'reductionbyevaluation', 'freeevaluations');
+
+// Prepare forms if we are editing or submitting an override.
+if ($edit !== null || $update !== null) {
+    // Compute users that are not already affected to another override.
+    if (!$vpl->is_group_activity()) {
+        $alreadyassignedusers = array();
+        foreach ($overrides as $override) {
+            if ($override->id != $edit && $override->id != $update && !empty($override->userids)) {
+                $alreadyassignedusers = array_merge($alreadyassignedusers, explode(',', $override->userids));
+            }
+        }
+        $availableusers = array_map('fullname',
+                array_filter(get_enrolled_users(context_module::instance($id)), function($user) use ($alreadyassignedusers) {
+                    return !in_array($user->id, $alreadyassignedusers);
+                }
+        ));
+    } else {
+        $availableusers = null;
+    }
+    // Compute groups that are not already affected to another override.
+    $groups = groups_get_all_groups($vpl->get_course()->id, 0, $vpl->get_course_module()->groupingid);
+    if (!empty($groups)) {
+        $alreadyassignedgroups = array();
+        foreach ($overrides as $override) {
+            if ($override->id != $edit && $override->id != $update && !empty($override->groupids)) {
+                $alreadyassignedgroups = array_merge($alreadyassignedgroups, explode(',', $override->groupids));
+            }
+        }
+        $availablegroups = array_filter($groups, function($group) use ($alreadyassignedgroups) {
+            return !in_array($group->id, $alreadyassignedgroups);
+        });
+        $availablegroups = array_map(function($group) {
+            return $group->name;
+        }, $availablegroups);
+    } else {
+        $availablegroups = null;
+    }
+
+    // Prepare forms.
+    $usersform = new vpl_override_users_form($availableusers, $availablegroups);
+    $overrideid = $edit;
+    if ($overrideid === null) {
+        $overrideid = $update;
+    }
+    $optionsform = new vpl_override_options_form($id, $overrideid);
+}
+
+if ($delete !== null) {
+    $overrideid = $delete;
+    if (isset($overrides[$overrideid])) {
+        $override = $overrides[$overrideid];
+        // Delete associated calendar events.
+        $vpl->update_override_calendar_events($override, null, true);
+        // Delete the override.
+        $DB->delete_records( VPL_OVERRIDES, array('id' => $overrideid) );
+        $DB->delete_records( VPL_ASSIGNED_OVERRIDES, array('override' => $overrideid) );
+        \mod_vpl\event\override_deleted::log($vpl, $overrideid);
+    }
+    // Properly reload the page.
+    redirect(new moodle_url('/mod/vpl/forms/overrides.php', array( 'id' => $id )));
+}
+
+if ($update !== null) {
+    // Update or create an override.
+    $override = $optionsform->get_data();
+    unset($override->id); // The id field of the form is not the override id - do not use it.
+    if ($override !== null) {
+        foreach ($fields as $field) {
+            if (!isset($override->{'override_' . $field})) {
+                $override->$field = null;
+            }
+        }
+        if (empty($override->userids)) {
+            $override->userids = null;
+        }
+        if (empty($override->groupids)) {
+            $override->groupids = null;
+        }
+        $override->vpl = $vplid;
+        $old = array(
+                'userids' => array(),
+                'groupids' => array()
+        );
+        if ($update == 0) {
+            // Create the override.
+            $newid = $DB->insert_record( VPL_OVERRIDES, $override );
+            $override->id = $newid;
+            $oldoverride = null;
+            \mod_vpl\event\override_created::log($vpl, $newid);
+        } else {
+            // Update the override.
+            $override->id = $update;
+            if (isset($overrides[$override->id])) {
+                $oldoverride = $overrides[$override->id];
+                if (!empty($oldoverride->userids)) {
+                    $old['userids'] = explode(',', $oldoverride->userids);
+                }
+                if (!empty($oldoverride->groupids)) {
+                    $old['groupids'] = explode(',', $oldoverride->groupids);
+                }
+            } else {
+                $oldoverride = null;
+            }
+            $DB->update_record( VPL_OVERRIDES, $override );
+            \mod_vpl\event\override_updated::log($vpl, $update);
+        }
+
+        $record = array(
+                'vpl' => $override->vpl,
+                'override' => $override->id
+        );
+        // Process users and groups for the updated override, to update assigned overrides table.
+        foreach (array('userid', 'groupid') as $key) {
+            $record['userid'] = null;
+            $record['groupid'] = null;
+            $ids = $key . 's';
+            sort($old[$ids]);
+            if (!empty($override->$ids)) {
+                $newids = explode(',', $override->$ids);
+            } else {
+                $newids = array();
+            }
+            sort($newids);
+            $i = 0;
+            $n = count($old[$ids]);
+            $j = 0;
+            $m = count($newids);
+            // Walk simultaneously through both arrays.
+            while ($i < $n || $j < $m) {
+                if ($i == $n || ($j < $m && $old[$ids][$i] > $newids[$j])) {
+                    // Insert new user/group.
+                    $record[$key] = $newids[$j];
+                    $DB->insert_record( VPL_ASSIGNED_OVERRIDES, $record);
+                    $j++;
+                } else if ($j == $m || ($newids[$j] > $old[$ids][$i])) {
+                    // Remove old user/group.
+                    $DB->delete_records( VPL_ASSIGNED_OVERRIDES, array(
+                            'vpl' => $override->vpl,
+                            'override' => $override->id,
+                            $key => $old[$ids][$i]
+                    ));
+                    $i++;
+                } else {
+                    // This user/group was and is still there, skip.
+                    $i++;
+                    $j++;
+                }
+            }
+        }
+        // Create or update associated calendar events.
+        $vpl->update_override_calendar_events($override, $oldoverride);
+    }
+    // Do not redirect if validation fails.
+    if ($optionsform->is_validated() || $optionsform->is_cancelled()) {
+        // Properly reload the page.
+        redirect(new moodle_url('/mod/vpl/forms/overrides.php', array( 'id' => $id )));
+    }
+}
+
+$PAGE->force_settings_menu();
+$PAGE->requires->css( new moodle_url( '/mod/vpl/css/overrides.css' ) );
+$vpl->print_header( get_string( 'overrides', VPL ) );
+$vpl->print_heading_with_help( 'overrides' );
+echo $OUTPUT->box_start();
+
+$table = new html_table();
+
+$table->head = array(
+        '#',
+        get_string('override_users', VPL) . $OUTPUT->help_icon('override_users', VPL),
+        get_string('override_options', VPL),
+        get_string('actions')
+);
+$table->align = array (
+        'right',
+        'left',
+        'left'
+);
+$table->size = array (
+        '2em',
+        '35%',
+        '',
+        '10%'
+);
+
+$table->data = array();
+
+// Populate table with existing overrides.
+$i = 1;
+foreach ($overrides as $override) {
+    if ($edit == $override->id) {
+        // This is the override being edited: fill and display the forms.
+        $usersform->set_data(array(
+                'users' => explode(',', $override->userids),
+                'groups' => explode(',', $override->groupids)
+        ));
+        $users = $usersform->render();
+        $formdata = array();
+        foreach ($fields as $field) {
+            if ($override->$field === null) {
+                $formdata[$field] = $vpl->get_instance()->$field;
+                $formdata['override_' . $field] = false;
+            } else {
+                $formdata[$field] = $override->$field;
+                $formdata['override_' . $field] = true;
+            }
+        }
+        $optionsform->set_data($formdata);
+        $overridedata = $optionsform->render();
+    } else {
+        // Set up a proper display for affected users and groups.
+        $users = array();
+        if (!empty($override->userids)) {
+            $users = array_map('fullname', $DB->get_records_list('user', 'id', explode(',', $override->userids), 'id'));
+        }
+        if (!empty($override->groupids)) {
+            $users = array_merge($users, array_map(function($group) {
+                return '<i class="fa fa-fw fa-group"></i>&nbsp;' . $group->name;
+            }, $DB->get_records_list('groups', 'id', explode(',', $override->groupids), 'id')));
+        }
+        $users = implode(', ', $users);
+        if ($users == '') {
+            $users = get_string('none');
+        }
+
+        // Display active override options.
+        $overridedata = '';
+        foreach (array('startdate', 'duedate') as $datefield) {
+            if ($override->$datefield !== null) {
+                $overridedata .= get_string($datefield, VPL) . ': ';
+                if ($override->$datefield > 0) {
+                    $overridedata .= userdate($override->$datefield);
+                } else {
+                    $overridedata .= get_string('disabled', VPL);
+                }
+                $overridedata .= '<br>';
+            }
+        }
+        foreach (array('reductionbyevaluation', 'freeevaluations') as $field) {
+            if ($override->$field !== null) {
+                $overridedata .= get_string($field, VPL) . ': ' . $override->$field . '<br>';
+            }
+        }
+        if ($overridedata == '') {
+            $overridedata = get_string('none');
+        }
+    }
+    $table->data[] = array($i++, $users, $overridedata, vpl_get_overrideactions($id, $override->id, $edit));
+}
+
+if ($edit === 0) {
+    // A new override is being created, put an additional row at the end.
+    $users = $usersform->render();
+    $formdata = array();
+    foreach ($fields as $field) {
+        $formdata[$field] = $vpl->get_instance()->$field;
+        $formdata['override_' . $field] = false;
+    }
+    $optionsform->set_data($formdata);
+    $overridedata = $optionsform->render();
+    $table->data[] = array('', $users, $overridedata, vpl_get_overrideactions($id, 0, 0));
+}
+
+echo html_writer::table($table);
+
+if ($edit === null) {
+    // No override is being edited, add a button to create one.
+    echo '<a href="?id=' . $id . '&edit=0" class="btn btn-secondary">' . get_string('addoverride', VPL) . '</a>';
+}
+
+echo $OUTPUT->box_end();
+$vpl->print_footer();

--- a/jscript/override.js
+++ b/jscript/override.js
@@ -1,0 +1,48 @@
+// This file is part of VPL for Moodle - http://vpl.dis.ulpgc.es/
+//
+// VPL for Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// VPL for Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with VPL for Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * JavaScript functions to help override form
+ * @package mod_vpl
+ * @copyright 2021 Astor Bizard
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/* globals VPL: true */
+
+(function() {
+    if (typeof VPL != 'object') {
+        VPL = {};
+    }
+    var usersForm = 'vpl_override_users_form';
+    var optionsForm = 'vpl_override_options_form';
+    VPL.submitOverrideForms = function() {
+        var users = [];
+        var groups = [];
+        for(var [name, value] of new FormData(document.getElementById(usersForm))) {
+            if (name == 'users[]') {
+                users.push(value);
+            } else if (name == 'groups[]') {
+                groups.push(value);
+            }
+        };
+        document.querySelector('#' + optionsForm + ' [name=userids]').value = users.join(',');
+        document.querySelector('#' + optionsForm + ' [name=groupids]').value = groups.join(',');
+        document.querySelector('#' + optionsForm + ' [name=submitbutton]').click();
+    };
+    VPL.cancelOverrideForms = function() {
+        document.querySelector('#' + optionsForm + ' [name=cancel]').click();
+    };
+})();

--- a/lang/en/vpl.php
+++ b/lang/en/vpl.php
@@ -25,6 +25,7 @@ $string ['acceptcertificatesnote'] = "<p>You are using an encrypted connection.<
 <p>If you have problems with this process, you can try to use a http (unencrypted) connection or other browser.</p>
 <p>Please, click on the following links (server #) and accept the offered certificate.</p>";
 $string ['addfile'] = 'Add file';
+$string ['addoverride'] = 'Add an override';
 $string ['advanced'] = 'Advanced';
 $string ['allfiles'] = 'All files';
 $string ['allsubmissions'] = 'All submissions';
@@ -47,6 +48,7 @@ $string ['clipboard'] = 'Clipboard';
 $string ['closed'] = 'Closed';
 $string ['comments'] = 'Comments';
 $string ['compilation'] = 'Compilation';
+$string ['confirmoverridedeletion'] = 'Are you sure you want to delete this override set?';
 $string ['connected'] = 'connected';
 $string ['connecting'] = 'connecting';
 $string ['connection_closed'] = 'connection closed';
@@ -74,6 +76,7 @@ $string ['delete_file_q'] = 'Delete file?';
 $string ['deleteallsubmissions'] = 'Delete all submissions';
 $string ['description'] = 'Description';
 $string ['diff'] = 'diff';
+$string ['disabled'] = 'Disabled';
 $string ['discard_submission_period'] = 'Discard submission period';
 $string ['discard_submission_period_description'] = 'For each student and assignment, the system tries to discard submissions. The system keep the last one and at least a submission for every period';
 $string ['download'] = 'Download';
@@ -206,6 +209,11 @@ $string ['optionssaved'] = 'Options have been saved';
 $string ['origin'] = 'Origin';
 $string ['othersources'] = 'Other sources to add to the scan';
 $string ['outofmemory'] = 'Out of memory';
+$string ['override'] = 'Override';
+$string ['overridefor'] = '{$a->base} - override for {$a->for}';
+$string ['overrides'] = 'Overrides';
+$string ['override_options'] = 'Override options';
+$string ['override_users'] = 'Affected users';
 $string ['paste'] = 'Paste';
 $string ['pluginadministration'] = 'VPL administration';
 $string ['pluginname'] = 'Virtual programming lab';
@@ -238,11 +246,16 @@ $string ['privacy:metadata:vpl_assigned_variations'] = 'Information of the activ
 $string ['privacy:metadata:vpl_assigned_variations:userid'] = 'User DB id.';
 $string ['privacy:metadata:vpl_assigned_variations:vplid'] = 'VPL DB id';
 $string ['privacy:metadata:vpl_assigned_variations:description'] = 'Description of the assigned variation';
+$string ['privacy:metadata:vpl_assigned_overrides'] = 'Information of the activity settings overrides assigned, if any';
+$string ['privacy:metadata:vpl_assigned_overrides:vplid'] = 'VPL DB id';
+$string ['privacy:metadata:vpl_assigned_overrides:userid'] = 'User DB id';
+$string ['privacy:metadata:vpl_assigned_overrides:overrideid'] = 'Assigned override id';
 $string ['privacy:metadata:vpl_running_processes'] = 'Information of user\'s running processes on this activity ';
 $string ['privacy:metadata:vpl_running_processes:userid'] = 'User DB id.';
 $string ['privacy:metadata:vpl_running_processes:vplid'] = 'VPL DB id';
 $string ['privacy:metadata:vpl_running_processes:server'] = 'Server that runs the task';
 $string ['privacy:metadata:vpl_running_processes:starttime'] = 'Date the task starts running';
+$string ['privacy:overridepath'] = 'assigned_override';
 $string ['privacy:submissionpath'] = 'submission_{$a}';
 $string ['privacy:variationpath'] = 'assigned_variation';
 $string ['privacy:runningprocesspath'] = 'running_process_{$a}';
@@ -420,6 +433,11 @@ $string ['modulename_help'] = '<p>VPL is a activity module for Moodle that manag
 </ul>
 <p><a href="http://vpl.dis.ulpgc.es">Virtual Programming lab Home Page</a></p>';
 $string ['modulename_link'] = 'mod/vpl/view';
+$string ['override_help'] = 'If "Override" is checked, this setting will be overriden with selected value for affected users.';
+$string ['override_users_help'] = 'One user/group can only be affected to one override set.<br>
+If a user is affected to one set and one group he is a member of is affected to another, then by-user affectation prevails.<br>
+If a user is a member of several groups affected to several sets, the first one in the table prevails.';
+$string ['overrides_help'] = 'A set of settings can be overriden for an activity. These settings will override activity settings for affected users and groups.';
 $string ['requestedfiles_help'] = '<p>Here you set names and its initial content up for the requested files to the max number of files that was set in the basic description of the activity.</p>
 <p>If you don\'t set names for whole number of files, the unnamed files are optional and can have any name.</p>
 <p>You also can add contents to the requested files, so these contents will be available the first time that they will be opened with the editor, if no previous submission exists.</p>';

--- a/locallib.php
+++ b/locallib.php
@@ -30,6 +30,8 @@ define( 'VPL_JAILSERVERS', 'vpl_jailservers' );
 define( 'VPL_RUNNING_PROCESSES', 'vpl_running_processes' );
 define( 'VPL_VARIATIONS', 'vpl_variations' );
 define( 'VPL_ASSIGNED_VARIATIONS', 'vpl_assigned_variations' );
+define( 'VPL_OVERRIDES', 'vpl_overrides' );
+define( 'VPL_ASSIGNED_OVERRIDES', 'vpl_assigned_overrides' );
 define( 'VPL_GRADE_CAPABILITY', 'mod/vpl:grade' );
 define( 'VPL_VIEW_CAPABILITY', 'mod/vpl:view' );
 define( 'VPL_SUBMIT_CAPABILITY', 'mod/vpl:submit' );

--- a/similarity/user_similarity.php
+++ b/similarity/user_similarity.php
@@ -88,7 +88,7 @@ foreach ($ovpls as $ovpl) {
         continue;
     }
     // Open and limited => NO.
-    if ($timenow >= $instance->startdate && $timenow <= $instance->duedate) {
+    if ($timenow >= $vpl->get_effective_setting('startdate', $user->id) && $timenow <= $vpl->get_effective_setting('duedate', $user->id)) {
         continue;
     }
     // Can be graded => NO.

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -198,14 +198,14 @@ class mod_vpl_lib_testcase extends mod_vpl_base_testcase {
         foreach ($this->vpls as $vpl) {
             $instance = $vpl->get_instance();
             $instance->instance = $instance->id;
-            $sparms = array ('modulename' => VPL, 'instance' => $instance->id );
+            $sparms = array ('modulename' => VPL, 'instance' => $instance->id, 'priority' => null );
             $event = $DB->get_record( 'event', $sparms );
             $this->assertTrue(($event != false && $instance->duedate == $event->timestart) ||
                     ($event == false && $instance->duedate == 0),
                     $instance->name);
             $instance->duedate = time() + 1000;
             vpl_update_instance($instance);
-            $sparms = array ('modulename' => VPL, 'instance' => $instance->id );
+            $sparms = array ('modulename' => VPL, 'instance' => $instance->id, 'priority' => null );
             $event = $DB->get_record( 'event', $sparms );
             $this->assertTrue(($event != false && $instance->duedate == $event->timestart) ||
                     ($event == false && $instance->duedate == 0),
@@ -274,7 +274,9 @@ class mod_vpl_lib_testcase extends mod_vpl_base_testcase {
                     VPL_SUBMISSIONS,
                     VPL_VARIATIONS,
                     VPL_ASSIGNED_VARIATIONS,
-                    VPL_RUNNING_PROCESSES
+                    VPL_RUNNING_PROCESSES,
+                    VPL_OVERRIDES,
+                    VPL_ASSIGNED_OVERRIDES
             ];
             $parms = array('vpl' => $instance->id);
             foreach ($tables as $table) {
@@ -387,6 +389,9 @@ class mod_vpl_lib_testcase extends mod_vpl_base_testcase {
             $this->assertEquals(0, $count, $instance->name);
             $parms = array( 'vpl' => $instance->id);
             $count = $DB->count_records(VPL_ASSIGNED_VARIATIONS, $parms);
+            $this->assertEquals(0, $count, $instance->name);
+            $parms = array( 'vpl' => $instance->id);
+            $count = $DB->count_records(VPL_ASSIGNED_OVERRIDES, $parms);
             $this->assertEquals(0, $count, $instance->name);
             $directory = $CFG->dataroot . '/vpl_data/'. $instance->id . '/usersdata';
             $this->assertFalse(file_exists($directory) && is_dir($directory), $instance->name);

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -108,8 +108,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $users = [$this->students[0], $this->students[1], $this->students[2], $this->editingteachers[0], $this->students[5]];
         $usersvpls = [
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             [$this->vplonefile, $this->vplteamwork],
             [],
         ];
@@ -318,8 +318,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $users = [$this->students[0], $this->students[1], $this->students[2], $this->editingteachers[0], $this->students[5]];
         $usersvpls = [
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             [$this->vplonefile, $this->vplteamwork],
             []
         ];
@@ -349,8 +349,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $usersvpls = [
             [$this->vplonefile, $this->vplteamwork],
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             []
         ];
 
@@ -403,8 +403,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $usersvpls = [
             [$this->vplonefile, $this->vplteamwork],
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             []
         ];
 
@@ -437,8 +437,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $users = [$this->students[0], $this->students[1], $this->students[2], $this->editingteachers[0], $this->students[5]];
         $usersvpls = [
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             [$this->vplonefile, $this->vplteamwork],
             []
         ];
@@ -473,8 +473,8 @@ class mod_vpl_privacy_provider_testcase extends mod_vpl_base_testcase {
         $users = [$this->students[0], $this->students[1], $this->students[2], $this->editingteachers[0], $this->students[5]];
         $usersvpls = [
             [$this->vplonefile, $this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork],
-            [$this->vplvariations],
+            [$this->vplmultifile, $this->vplvariations, $this->vplteamwork, $this->vploverrides],
+            [$this->vplvariations, $this->vploverrides],
             [$this->vplonefile, $this->vplteamwork],
             []
         ];

--- a/view.php
+++ b/view.php
@@ -78,8 +78,8 @@ $vpl->print_name();
 
 echo $OUTPUT->box_start();
 
-$vpl->print_submission_period();
-$vpl->print_submission_restriction();
+$vpl->print_submission_period( $userid );
+$vpl->print_submission_restriction( $userid );
 $vpl->print_variation( $userid );
 $vpl->print_fulldescription();
 

--- a/vpl.class.php
+++ b/vpl.class.php
@@ -1005,13 +1005,14 @@ class mod_vpl {
     /**
      * Check if it is submission period
      *
+     * @param int $userid (optional) Check for given user, current user if null.
      * @return bool
-     *
      */
-    public function is_submission_period() {
+    public function is_submission_period($userid = null) {
         $now = time();
-        $ret = $this->instance->startdate <= $now;
-        return $ret && ($this->instance->duedate == 0 || $this->instance->duedate >= $now);
+        $startdate = $this->get_effective_setting('startdate', $userid);
+        $duedate = $this->get_effective_setting('duedate', $userid);
+        return $startdate <= $now && ($duedate == 0 || $duedate >= $now);
     }
 
     /**
@@ -1034,15 +1035,16 @@ class mod_vpl {
     /**
      * this vpl instance admit submission
      *
+     * @param int $userid (optional) Check for given user, current user if null.
      * @return bool
      */
-    public function is_submit_able() {
+    public function is_submit_able($userid = null) {
         $cm = $this->get_course_module();
         $modinfo = get_fast_modinfo( $cm->course );
         $instance = $this->get_instance();
         $ret = true;
         $ret = $ret && $this->has_capability( VPL_SUBMIT_CAPABILITY );
-        $ret = $ret && $this->is_submission_period();
+        $ret = $ret && $this->is_submission_period( $userid );
         $ret = $ret && $modinfo->get_cm( $cm->id )->uservisible;
         // Manager or grader can always submit.
         $ret = $ret || $this->has_capability( VPL_GRADE_CAPABILITY );
@@ -1634,23 +1636,24 @@ class mod_vpl {
 
     /**
      * Show vpl submission period
+     * @param int $userid (optional) Show for given user, current user if null.
      */
-    public function print_submission_period() {
-        if ($this->instance->startdate == 0 && $this->instance->duedate == 0) {
-            return;
+    public function print_submission_period($userid = null) {
+        $startdate = $this->get_effective_setting('startdate', $userid);
+        if ($startdate) {
+            $this->print_restriction( 'startdate', userdate( $startdate ) );
         }
-        if ($this->instance->startdate) {
-            $this->print_restriction( 'startdate', userdate( $this->instance->startdate ) );
-        }
-        if ($this->instance->duedate) {
-            $this->print_restriction( 'duedate', userdate( $this->instance->duedate ) );
+        $duedate = $this->get_effective_setting('duedate', $userid);
+        if ($duedate) {
+            $this->print_restriction( 'duedate', userdate( $duedate ) );
         }
     }
 
     /**
      * Show vpl submission restriction
+     * @param int $userid (optional) Show for given user, current user if null.
      */
-    public function print_submission_restriction() {
+    public function print_submission_restriction($userid = null) {
         global $CFG, $USER;
         $filegroup = $this->get_required_fgm();
         $files = $filegroup->getfilelist();
@@ -1715,7 +1718,7 @@ class mod_vpl {
                 $this->print_restriction( get_string( 'gradessettings', 'core_grades' ), get_string( 'nograde' ), true );
             }
         }
-        $this->print_gradereduction();
+        $this->print_gradereduction($userid);
         if ($grader) {
             if (trim( $instance->password ) > '') {
                 $this->print_restriction( get_string( 'password' ), $stryes, true );
@@ -1800,13 +1803,17 @@ class mod_vpl {
     }
 
     /**
-     * Show short description
+     * Print grade reduction
+     * @param int $userid (optional) Print for given user, current user if null.
+     * @param boolean $return If true, return result instead of printing it.
      */
-    public function print_gradereduction($return = false) {
-        if ($this->instance->reductionbyevaluation > 0) {
-            $html = $this->str_restriction( 'reductionbyevaluation', $this->instance->reductionbyevaluation);
-            if ( $this->instance->freeevaluations > 0) {
-                $html .= ' ' . $this->str_restriction( 'freeevaluations', $this->instance->freeevaluations);
+    public function print_gradereduction($userid = null, $return = false) {
+        $reductionbyevaluation = $this->get_effective_setting('reductionbyevaluation', $userid);
+        if ($reductionbyevaluation > 0) {
+            $html = $this->str_restriction( 'reductionbyevaluation', $reductionbyevaluation);
+            $freeevaluations = $this->get_effective_setting('freeevaluations', $userid);
+            if ( $freeevaluations > 0) {
+                $html .= ' ' . $this->str_restriction( 'freeevaluations', $freeevaluations);
             }
             if ( $return ) {
                 return $html;
@@ -1961,5 +1968,140 @@ class mod_vpl {
             $ret [] = $variation->identification;
         }
         return $ret;
+    }
+
+    /**
+     * Cached settings of overrides, for get_effective_setting().
+     * @var array $overridensettings Array[ cmid => Array[ userid => {settings} ] ]
+     */
+    protected static $overridensettings = array();
+    /**
+     * Return effective setting for this vpl instance (taking overrides into account).
+     * @param string $setting Setting name (field of database record).
+     * @param int $userid (optional) Get for given user, current user if null.
+     * @return mixed The effective setting, as a database field.
+     */
+    public function get_effective_setting($setting, $userid = null) {
+        global $USER, $DB;
+        $fields = array('startdate', 'duedate', 'reductionbyevaluation', 'freeevaluations');
+        if (!in_array($setting, $fields)) {
+            return $this->instance->$setting;
+        }
+        if (!$userid) {
+            $userid = $USER->id;
+        }
+        if (!isset(self::$overridensettings[$this->cm->id])) {
+            self::$overridensettings[$this->cm->id] = array();
+        }
+        if (!isset(self::$overridensettings[$this->cm->id][$userid])) {
+            self::$overridensettings[$this->cm->id][$userid] = new stdClass();
+
+            $sql = 'SELECT ao.id as aoid, ao.override, ao.userid, ao.groupid, o.*
+                        FROM {vpl_assigned_overrides} ao
+                        JOIN {vpl_overrides} o ON ao.override = o.id
+                        WHERE o.vpl = :vplid AND (ao.userid = :userid OR ao.groupid IS NOT NULL)
+                        ORDER BY ao.override DESC';
+            $overrides = $DB->get_records_sql($sql, array('vplid' => $this->instance->id, 'userid' => $userid));
+
+            foreach ($overrides as $override) {
+                if (!empty($override->userid)) {
+                    // Found record for user.
+                    foreach ($fields as $field) {
+                        self::$overridensettings[$this->cm->id][$userid]->$field = $override->$field;
+                    }
+                    break; // User overrides take priority, do not search further.
+                }
+
+                if (groups_is_member($override->groupid, $userid)) {
+                    foreach ($fields as $field) {
+                        self::$overridensettings[$this->cm->id][$userid]->$field = $override->$field;
+                    }
+                }
+            }
+        }
+        if (isset(self::$overridensettings[$this->cm->id][$userid]->$setting) &&
+                self::$overridensettings[$this->cm->id][$userid]->$setting !== null) {
+                    return self::$overridensettings[$this->cm->id][$userid]->$setting;
+                } else {
+                    return $this->instance->$setting;
+                }
+    }
+
+    /**
+     * Update calendar events for duedate overrides.
+     * @param stdClass $override The override being created / updated / deleted.
+     *          It should contain joint data from vpl_overrides and vpl_assigned_overrides tables.
+     * @param stdClass $oldoverride The old override data (in case of an update).
+     * @param boolean $delete If true, simply delete all related events.
+     */
+    public function update_override_calendar_events($override, $oldoverride = null, $delete = false) {
+        global $DB, $CFG;
+        require_once($CFG->dirroot . '/calendar/lib.php');
+
+        $targets = array(
+                'userid' => CALENDAR_EVENT_USER_OVERRIDE_PRIORITY,
+                'groupid' => $override->id
+        );
+        foreach ($targets as $target => $priority) { // Process once for users and once for groups.
+            $params = array(
+                    'modulename' => VPL,
+                    'instance' => $this->instance->id,
+                    'priority' => $priority
+            );
+            if ($oldoverride !== null && !empty($oldoverride->{$target . 's'})) {
+                $oldtargets = array_fill_keys(explode(',', $oldoverride->{$target . 's'}), false);
+            } else {
+                $oldtargets = array();
+            }
+            if (!empty($override->{$target . 's'})) {
+                foreach (explode(',', $override->{$target . 's'}) as $userorgroupid) { // Loop over users or groups.
+                    $params[$target] = $userorgroupid;
+                    $currenteventid = $DB->get_field( 'event', 'id', $params ); // Get current calendar event.
+                    if (isset($override->duedate) && !$delete) {
+                        if ($target == 'userid') {
+                            $userorgroupname = fullname($DB->get_record( 'user', array('id' => $userorgroupid) ));
+                        } else {
+                            $userorgroupname = groups_get_group($userorgroupid)->name;
+                        }
+                        $newevent = vpl_create_event($this->instance, $this->instance->id);
+                        $newevent->name = get_string('overridefor', VPL, array(
+                                'base' => $newevent->name,
+                                'for' => $userorgroupname
+                        ));
+                        if ($target == 'userid') {
+                            // User overrides events do not show correctly if courseid is non zero.
+                            $newevent->courseid = 0;
+                        }
+                        $newevent->timestart = $override->duedate;
+                        $newevent->timesort = $override->duedate;
+                        $newevent->{$target} = $userorgroupid;
+                        $newevent->priority = $priority;
+                        if ($currenteventid === false) {
+                            // No event exist for current user or group, create a new one.
+                            calendar_event::create( $newevent );
+                        } else {
+                            // An event already exists, update it.
+                            calendar_event::load( $currenteventid )->update( $newevent );
+                        }
+                    } else {
+                        if ($currenteventid !== false) {
+                            calendar_event::load( $currenteventid )->delete();
+                        }
+                    }
+                    // This user or group is in newly processed data (or has already been removed).
+                    $oldtargets[$userorgroupid] = true;
+                }
+            }
+            // Discard events related to users or groups removed from override.
+            foreach ($oldtargets as $oldtarget => $tokeep) {
+                if (!$tokeep) {
+                    $params[$target] = $oldtarget;
+                    $eventid = $DB->get_field( 'event', 'id', $params );
+                    if ($eventid !== false) {
+                        calendar_event::load( $eventid )->delete();
+                    }
+                }
+            }
+        }
     }
 }

--- a/vpl.class.php
+++ b/vpl.class.php
@@ -360,7 +360,7 @@ class mod_vpl {
                 $ret .= ' (' . $grouping->name . ')';
             }
         }
-        return $ret;
+        return format_string($ret);
     }
 
     /**
@@ -1596,9 +1596,8 @@ class mod_vpl {
      * Show vpl name
      */
     public function print_name() {
-        echo '<h2>';
-        p( $this->get_printable_name() );
-        echo '</h2>';
+        global $OUTPUT;
+        echo $OUTPUT->heading($this->get_printable_name());
     }
 
     public function str_restriction($str, $value = null, $raw = false) {


### PR DESCRIPTION
This update adds override options for users and groups (resolves #83 ).
This applies to the following settings : due date, start date, reduction by automatic evaluation, and number of free evaluations.

The first commit also includes a small fix:
A VPL activity name is currently displayed without applying any filters (for example multilang).
This update fixes the problem (just added a simple call to format_string).