### PR TITLE
Declare basic indexation of name and intro for global search

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+namespace mod_vpl\search;
+
+defined('MOODLE_INTERNAL') || die();
+
+class activity extends \core_search\base_activity {
+
+    /**
+     * Returns true if this area uses file indexing.
+     *
+     * @return bool
+     */
+    public function uses_file_indexing() {
+        return true;
+    }
+}

--- a/lang/en/vpl.php
+++ b/lang/en/vpl.php
@@ -303,6 +303,7 @@ $string['scanningdir'] = 'Scanning directory ...';
 $string['scanoptions'] = 'Scan options';
 $string['scanother'] = 'Scan similarities in added sources';
 $string['scanzipfile'] = 'Zip file';
+$string['search:activity'] = 'Virtual Programming Lab - activity information';
 $string['sebkeys'] = 'SEB exam Key/s';
 $string['sebkeys_help'] = 'SEB exam key(s) (max 3) obtained from .seb file<br>It is more reliable than only browser check.<br>https://safeexambrowser.org';
 $string['sebrequired'] = 'SEB browser required';


### PR DESCRIPTION
This addition will allow Moodle's global search engine to index and search through VPLs names and descriptions (as described on the [Search API documentation](https://docs.moodle.org/dev/Search_API) in the most basic usage for activities).