### PR TITLE
Allow whitespaces before and after <|-- and --|> (closes #168)

### DIFF
--- a/vpl_submission.class.php
+++ b/vpl_submission.class.php
@@ -936,11 +936,11 @@ class mod_vpl_submission {
     public static function find_proposedcomment(&$text) {
         $usecrnl = vpl_detect_newline($text) == "\r\n";
         if ($usecrnl) {
-            $startcommentreg = '/^\\s*(Comment :=>>([^\\r\\n]*)|<\\|--)\\s*\\r?$/m';
-            $endcommentreg = '/^\\s*--\\|>\\s*\\r?$/m';
+            $startcommentreg = '/^[ \\t]*(Comment :=>>([^\\r\\n]*)|<\\|--)[ \\t]*\\r?$/m';
+            $endcommentreg = '/^[ \\t]*--\\|>[ \\t]*\\r?$/m';
         } else {
-            $startcommentreg = '/^\\s*(Comment :=>>(.*)|<\\|--)\\s*$/m';
-            $endcommentreg = '/^\\s*--\\|>\\s*$/m';
+            $startcommentreg = '/^[ \\t]*(Comment :=>>(.*)|<\\|--)[ \\t]*$/m';
+            $endcommentreg = '/^[ \\t]*--\\|>[ \\t]*$/m';
         }
         $comments = '';
         $offset = 0;

--- a/vpl_submission.class.php
+++ b/vpl_submission.class.php
@@ -936,11 +936,11 @@ class mod_vpl_submission {
     public static function find_proposedcomment(&$text) {
         $usecrnl = vpl_detect_newline($text) == "\r\n";
         if ($usecrnl) {
-            $startcommentreg = '/^(Comment :=>>([^\\r\\n]*)|<\\|--)\\r?$/m';
-            $endcommentreg = '/^--\\|>\\r?$/m';
+            $startcommentreg = '/^(Comment :=>>([^\\r\\n]*)|\\s*<\\|--\\s*)\\r?$/m';
+            $endcommentreg = '/^\\s*--\\|>\\s*\\r?$/m';
         } else {
-            $startcommentreg = '/^(Comment :=>>(.*)|<\\|--)$/m';
-            $endcommentreg = '/^--\\|>$/m';
+            $startcommentreg = '/^(Comment :=>>(.*)|\\s*<\\|--\\s*)$/m';
+            $endcommentreg = '/^\\s*--\\|>\\s*$/m';
         }
         $comments = '';
         $offset = 0;

--- a/vpl_submission.class.php
+++ b/vpl_submission.class.php
@@ -936,10 +936,10 @@ class mod_vpl_submission {
     public static function find_proposedcomment(&$text) {
         $usecrnl = vpl_detect_newline($text) == "\r\n";
         if ($usecrnl) {
-            $startcommentreg = '/^(Comment :=>>([^\\r\\n]*)|\\s*<\\|--\\s*)\\r?$/m';
+            $startcommentreg = '/^\\s*(Comment :=>>([^\\r\\n]*)|<\\|--)\\s*\\r?$/m';
             $endcommentreg = '/^\\s*--\\|>\\s*\\r?$/m';
         } else {
-            $startcommentreg = '/^(Comment :=>>(.*)|\\s*<\\|--\\s*)$/m';
+            $startcommentreg = '/^\\s*(Comment :=>>(.*)|<\\|--)\\s*$/m';
             $endcommentreg = '/^\\s*--\\|>\\s*$/m';
         }
         $comments = '';
@@ -949,7 +949,7 @@ class mod_vpl_submission {
             $result = preg_match($startcommentreg, $text, $matches, PREG_OFFSET_CAPTURE, $offset);
             if ( $result == 1) {
                 $found = $matches[1][0];
-                if ( trim($found) == self::BEGINCOMMENTTAG ) { // Block comment start.
+                if ( $found == self::BEGINCOMMENTTAG ) { // Block comment start.
                     $posstart = $matches[0][1] + strlen($matches[0][0]) + 1;
                     $result = preg_match($endcommentreg, $text, $matches, PREG_OFFSET_CAPTURE, $posstart);
                     if ($result == 1) { // Block comment end.

--- a/vpl_submission.class.php
+++ b/vpl_submission.class.php
@@ -949,7 +949,7 @@ class mod_vpl_submission {
             $result = preg_match($startcommentreg, $text, $matches, PREG_OFFSET_CAPTURE, $offset);
             if ( $result == 1) {
                 $found = $matches[1][0];
-                if ( $found == self::BEGINCOMMENTTAG ) { // Block comment start.
+                if ( trim($found) == self::BEGINCOMMENTTAG ) { // Block comment start.
                     $posstart = $matches[0][1] + strlen($matches[0][0]) + 1;
                     $result = preg_match($endcommentreg, $text, $matches, PREG_OFFSET_CAPTURE, $posstart);
                     if ($result == 1) { // Block comment end.


### PR DESCRIPTION
This acts as backward compatibility / non-regressive robustness, as is was allowed before update 4.2.