### PR TITLE
Add Moodle activity ID to execution environment variables

### DIFF
--- a/vpl_submission_CE.class.php
+++ b/vpl_submission_CE.class.php
@@ -405,6 +405,7 @@ class mod_vpl_submission_CE extends mod_vpl_submission {
         // Info send with script.
         $info = "#!/bin/bash\n";
         $info .= vpl_bash_export('VPL_LANG', vpl_get_lang());
+        $info .= vpl_bash_export('MOODLE_ACTIVITY_ID', $vpl->get_course_module()->id);
         if (isset($data->userid)) {
             $userid = $data->userid;
             $info .= vpl_bash_export('MOODLE_USER_ID',  $userid);

--- a/vpl_submission_CE.class.php
+++ b/vpl_submission_CE.class.php
@@ -405,6 +405,7 @@ class mod_vpl_submission_CE extends mod_vpl_submission {
         // Info send with script.
         $info = "#!/bin/bash\n";
         $info .= vpl_bash_export('VPL_LANG', vpl_get_lang());
+        $info .= vpl_bash_export('MOODLE_COURSE_ID', $vpl->get_course()->id);
         $info .= vpl_bash_export('MOODLE_ACTIVITY_ID', $vpl->get_course_module()->id);
         if (isset($data->userid)) {
             $userid = $data->userid;


### PR DESCRIPTION
This is a really simple change that exposes the Moodle activity ID (the one that is used in all the activity URL-s) and the Moodle course ID as environment variables to the code running in VPL.

The main use case for this is external integrations. For example, we send some results to an external web service from each VPL execution and for a seamless experience, we would like to have links in the external web service that take you to your submission or the VPL activity page in Moodle. To generate these links the service needs to know the activity ID. Currently we input it manually under execution files, but that is tedious and error-prone. This pull request would make it easy to read the activity ID from an environment variable and automatically send it to the external service together with the results.

The course ID is also useful for external integrations. For example, in our service we aggregate results for each course and in order to do that we need to know what activities belong to what course. Currently we maintain this info manually, but with this pull request it would be easy to read the course ID from environment variables and automatically send it to the external service together with the rest of the submission info.

As far as I know this change is fully backwards compatible and has no risk of causing any problems. I tested it in a local Moodle instance and everything seemed to work exactly as intended.