### PR TITLE
Make compile & execute result monospace

### DIFF
--- a/editor/VPLIDE.css
+++ b/editor/VPLIDE.css
@@ -273,6 +273,9 @@ img.vpl_ide_file {
     white-space: pre-wrap;
 }
 
+/* .ui-widget overrides fonts, so we have to increase the specificity */
+.ui-widget.vpl_ide_accordion_c_compilation,
+.ui-widget.vpl_ide_accordion_c_execution,
 .vpl_ide_accordion_c_compilation,
 .vpl_ide_accordion_c_execution {
     font-family:


### PR DESCRIPTION
Currently, compile & execute outputs are not monospace because the class `ui-widget` overrides their fonts.
I (probably) dealt with this problem by increasing their specificity.