### PR TITLE
Fix duplicate display of grade reduction settings

### DIFF
--- a/vpl.class.php
+++ b/vpl.class.php
@@ -2048,7 +2048,7 @@ class mod_vpl {
             if ( $freeevaluations > 0) {
                 $html .= ' ' . $this->str_restriction( 'freeevaluations', $freeevaluations);
             }
-            $html .= $html . '<br>';
+            $html .= '<br>';
         }
         return $html;
     }


### PR DESCRIPTION
Grade reduction settings are displayed duplicated on Description page.  
This fixes the (minor) problem.