### PR TITLE
Add help on execution options (basedon, automatic grading, evaluate on submission)

### DIFF
--- a/forms/executionoptions.php
+++ b/forms/executionoptions.php
@@ -94,6 +94,7 @@ class mod_vpl_executionoptions_form extends moodleform {
         $basedonlist[0] = get_string( 'select' );
         $mform->addElement( 'select', 'basedon', $strbasedon, $basedonlist );
         $mform->setDefault( 'basedon', $instance->basedon );
+        $mform->addHelpButton( 'basedon', 'basedon', VPL );
 
         $strautodetect = get_string('autodetect', VPL);
         $strrunscript = get_string('runscript', VPL);
@@ -117,9 +118,11 @@ class mod_vpl_executionoptions_form extends moodleform {
         $mform->addElement( 'selectyesno', 'evaluateonsubmission', get_string( 'evaluateonsubmission', VPL ) );
         $mform->setDefault( 'evaluateonsubmission', $instance->evaluateonsubmission );
         $mform->disabledIf( 'evaluateonsubmission', 'evaluate', 'eq', 0 );
+        $mform->addHelpButton( 'evaluateonsubmission', 'evaluateonsubmission', VPL );
         $mform->addElement( 'selectyesno', 'automaticgrading', get_string( 'automaticgrading', VPL ) );
         $mform->setDefault( 'automaticgrading', $instance->automaticgrading );
         $mform->disabledIf( 'automaticgrading', 'evaluate', 'eq', 0 );
+        $mform->addHelpButton( 'automaticgrading', 'automaticgrading', VPL );
 
         $mform->addElement( 'submit', 'saveoptions', get_string( 'saveoptions', VPL ) );
     }

--- a/lang/en/vpl.php
+++ b/lang/en/vpl.php
@@ -34,12 +34,16 @@ $string['attemptnumber'] = 'Attempt number {$a}';
 $string['autodetect'] = 'Autodetect';
 $string['automaticevaluation'] = 'Automatic evaluation';
 $string['automaticgrading'] = 'Automatic grade';
+$string['automaticgrading_help'] = 'If set to Yes, the grade proposed by the automatic evaluation will be applied as the grade for this activity.<br>
+If set to No, no grade will be applied by this activity; teachers will have to review proposed grades in order to apply them manually.';
 $string['averageperiods'] = 'Average periods {$a}';
 $string['averagetime'] = 'Average time {$a}';
 $string['basedon'] = 'Based on';
 $string['basedon_missed'] = 'The based-on activity was missed by restoring/importing. Please, include "{$a}"';
 $string['basedon_chain_broken'] = 'Error: The chain of based-on activities is broken. Please, review based-on activities.';
 $string['basedon_deleted'] = 'Error: The based-on activity missed (was deleted?). Please, set the based-on activity.';
+$string['basedon_help'] = 'This option describes a system of inheritance for execution scripts.<br>
+Execution scripts will be concatenated, first the parent (the base), then the child (this VPL). Several bases can be chained, resulting in multiple concatenations.';
 $string['basic'] = 'Basic';
 $string['binaryfile'] = 'Binary File';
 $string['breakpoint'] = 'Breakpoint';
@@ -104,7 +108,8 @@ $string['error:recursivedefinition'] = "Recursive basedon VPL definition";
 $string['error:uninstalling'] = 'Error uninstalling VPL. All data may have not been deleted';
 $string['error:zipnotfound'] = 'ZIP file not found';
 $string['evaluate'] = 'Evaluate';
-$string['evaluateonsubmission'] = 'Evaluate just on submission';
+$string['evaluateonsubmission'] = 'Evaluate upon files submission';
+$string['evaluateonsubmission_help'] = 'If set to Yes, performs an evaluation upon files submission via the "Submission" tab. This does not affect submissions via the "Edit" tab.';
 $string['evaluating'] = 'Evaluating';
 $string['evaluation'] = 'Evaluation';
 $string['examples'] = 'Examples';


### PR DESCRIPTION
Execution options such as "Based on", "Automatic grading" and "Evaluate on submission" can be hard to understand when first using VPL. This adds a bit of help as well as re-formulating one label for clarity.