### PR TITLE
Add information on execution resources limits form

### DIFF
--- a/forms/executionlimits.php
+++ b/forms/executionlimits.php
@@ -43,30 +43,45 @@ class mod_vpl_executionlimits_form extends moodleform {
         $mform->addElement( 'hidden', 'id', $id );
         $mform->setType( 'id', PARAM_INT );
         $mform->addElement( 'header', 'header_execution_limits', get_string( 'resourcelimits', VPL ) );
-        $mform->addElement( 'select', 'maxexetime', get_string( 'maxexetime', VPL )
-                           , vpl_get_select_time( ( int ) $plugincfg->maxexetime ) );
-        $mform->setType( 'maxexetime', PARAM_INT );
-        if ($instance->maxexetime) {
-            $mform->setDefault( 'maxexetime', $instance->maxexetime );
-        }
-        $mform->addElement( 'select', 'maxexememory', get_string( 'maxexememory', VPL )
-                           , vpl_get_select_sizes( 16 * 1024 * 1024, ( int ) $plugincfg->maxexememory ) );
-        $mform->setType( 'maxexememory', PARAM_INT );
-        if ($instance->maxexememory) {
-            $mform->setDefault( 'maxexememory', $instance->maxexememory );
-        }
-        $mform->addElement( 'select', 'maxexefilesize', get_string( 'maxexefilesize', VPL )
-                           , vpl_get_select_sizes( 1024 * 256, ( int ) $plugincfg->maxexefilesize ) );
-        $mform->setType( 'maxexefilesize', PARAM_INT );
-        if ($instance->maxexefilesize) {
-            $mform->setDefault( 'maxexefilesize', $instance->maxexefilesize );
-        }
+
+        self::add_resource_limit_select($mform, 'maxexetime', get_string( 'maxexetime', VPL ),
+                vpl_get_select_time( ( int ) $plugincfg->maxexetime ),
+                $plugincfg->defaultexetime, $instance->maxexetime);
+
+        self::add_resource_limit_select($mform, 'maxexememory', get_string( 'maxexememory', VPL ),
+                vpl_get_select_sizes( 16 * 1024 * 1024, ( int ) $plugincfg->maxexememory ),
+                $plugincfg->defaultexememory, $instance->maxexememory);
+
+        self::add_resource_limit_select($mform, 'maxexefilesize', get_string( 'maxexefilesize', VPL ),
+                vpl_get_select_sizes( 1024 * 256, ( int ) $plugincfg->maxexefilesize ),
+                $plugincfg->defaultexefilesize, $instance->maxexefilesize);
+
         $mform->addElement( 'text', 'maxexeprocesses', get_string( 'maxexeprocesses', VPL ) );
         $mform->setType( 'maxexeprocesses', PARAM_INT );
         if ($instance->maxexeprocesses) {
             $mform->setDefault( 'maxexeprocesses', $instance->maxexeprocesses );
         }
         $mform->addElement( 'submit', 'savelimitoptions', get_string( 'saveoptions', VPL ) );
+    }
+
+    /**
+     * Adds a select element to the resource limits form.
+     * @param MoodleQuickForm $mform The form to which the element will be added.
+     * @param string $name The name of the element.
+     * @param string $label The label of the element.
+     * @param array $selectoptions The selectable options of the element.
+     *  The [0] => 'select' option will be replaced by a localized string describing the default value.
+     * @param int $defaultvalue The default value to use when no other value is selected.
+     * @param int $currentvalue The value to which the element should be set when displaying the form.
+     */
+    private static function add_resource_limit_select($mform, $name, $label, $selectoptions, $defaultvalue, $currentvalue) {
+        $defaultvaluestring = $selectoptions[ vpl_get_array_key($selectoptions, $defaultvalue) ];
+        $selectoptions[0] = get_string('default') . ' (' . $defaultvaluestring . ')';
+        $mform->addElement( 'select', $name, $label, $selectoptions );
+        $mform->setType( $name, PARAM_INT );
+        if ($currentvalue) {
+            $mform->setDefault( $name, $currentvalue );
+        }
     }
 }
 
@@ -80,7 +95,7 @@ $vpl->prepare_page( 'forms/executionlimits.php', [
 vpl_include_jsfile( 'hideshow.js' );
 $vpl->require_capability( VPL_MANAGE_CAPABILITY );
 // Display page.
-$vpl->print_header( get_string( 'execution', VPL ) );
+$vpl->print_header( get_string( 'resourcelimits', VPL ) );
 $vpl->print_heading_with_help( 'resourcelimits' );
 
 $mform = new mod_vpl_executionlimits_form( 'executionlimits.php', $vpl );

--- a/forms/executionlimits.php
+++ b/forms/executionlimits.php
@@ -44,17 +44,22 @@ class mod_vpl_executionlimits_form extends moodleform {
         $mform->setType( 'id', PARAM_INT );
         $mform->addElement( 'header', 'header_execution_limits', get_string( 'resourcelimits', VPL ) );
 
-        self::add_resource_limit_select($mform, 'maxexetime', get_string( 'maxexetime', VPL ),
-                vpl_get_select_time( ( int ) $plugincfg->maxexetime ),
-                $plugincfg->defaultexetime, $instance->maxexetime);
-
-        self::add_resource_limit_select($mform, 'maxexememory', get_string( 'maxexememory', VPL ),
-                vpl_get_select_sizes( 16 * 1024 * 1024, ( int ) $plugincfg->maxexememory ),
-                $plugincfg->defaultexememory, $instance->maxexememory);
-
-        self::add_resource_limit_select($mform, 'maxexefilesize', get_string( 'maxexefilesize', VPL ),
-                vpl_get_select_sizes( 1024 * 256, ( int ) $plugincfg->maxexefilesize ),
-                $plugincfg->defaultexefilesize, $instance->maxexefilesize);
+        $settings = [
+                'exetime' => vpl_get_select_time( ( int ) $plugincfg->maxexetime ),
+                'exememory' => vpl_get_select_sizes( 16 * 1024 * 1024, ( int ) $plugincfg->maxexememory ),
+                'exefilesize' => vpl_get_select_sizes( 1024 * 256, ( int ) $plugincfg->maxexefilesize ),
+        ];
+        foreach ($settings as $name => $options) {
+            $inheritedlimit = $instance->basedon ? self::get_closest_set_execution_limit($instance->basedon, 'max' . $name) : 0;
+            $defaultvaluestring = trim($options[ vpl_get_array_key($options, $inheritedlimit ?: $plugincfg->{'default' . $name}) ]);
+            if ($inheritedlimit) {
+                $defaultvaluestring = get_string('inherit', VPL) . ' (' . $defaultvaluestring . ')';
+            } else {
+                $defaultvaluestring = get_string('default') . ' (' . $defaultvaluestring . ')';
+            }
+            self::add_resource_limit_select($mform, 'max' . $name, get_string( 'max' . $name, VPL ),
+                    $options, $defaultvaluestring, $instance->{'max' . $name});
+        }
 
         $mform->addElement( 'text', 'maxexeprocesses', get_string( 'maxexeprocesses', VPL ) );
         $mform->setType( 'maxexeprocesses', PARAM_INT );
@@ -74,13 +79,29 @@ class mod_vpl_executionlimits_form extends moodleform {
      * @param int $defaultvalue The default value to use when no other value is selected.
      * @param int $currentvalue The value to which the element should be set when displaying the form.
      */
-    private static function add_resource_limit_select($mform, $name, $label, $selectoptions, $defaultvalue, $currentvalue) {
-        $defaultvaluestring = $selectoptions[ vpl_get_array_key($selectoptions, $defaultvalue) ];
-        $selectoptions[0] = get_string('default') . ' (' . $defaultvaluestring . ')';
+    private static function add_resource_limit_select($mform, $name, $label, $selectoptions, $defaultvaluestring, $currentvalue) {
+        $selectoptions[0] = $defaultvaluestring;
         $mform->addElement( 'select', $name, $label, $selectoptions );
         $mform->setType( $name, PARAM_INT );
         if ($currentvalue) {
             $mform->setDefault( $name, $currentvalue );
+        }
+    }
+
+    /**
+     * Retrieve the first non-empty setting in the basedon chain.
+     * @param number $instanceid ID in 'vpl' table
+     * @param string $field Setting name (DB column name)
+     */
+    private static function get_closest_set_execution_limit($instanceid, $field) {
+        global $DB;
+        $vplinstance = $DB->get_record('vpl', [ 'id' => $instanceid ]);
+        if ($vplinstance->{$field}) {
+            return $vplinstance->{$field};
+        } else if ($vplinstance->basedon) {
+            return self::get_closest_set_execution_limit($vplinstance->basedon, $field);
+        } else {
+            return 0;
         }
     }
 }

--- a/lang/en/vpl.php
+++ b/lang/en/vpl.php
@@ -158,6 +158,7 @@ $string['indicator:cognitivedepth_help'] = 'This indicator is based on the cogni
 $string['indicator:socialbreadth'] = 'VPL social';
 $string['indicator:socialbreadth_help'] = 'This indicator is based on the social breadth reached by the student in an VPL activity.';
 $string['individualwork'] = 'Individual work';
+$string['inherit'] = 'Inherit';
 $string['instanceselection'] = 'VPL selection';
 $string['isexample'] = 'This activity acts as example';
 $string['jail_servers'] = 'Execution servers list';


### PR DESCRIPTION
Currently when viewing the Maximum execution resources limits form, the default value displays only "Select".
This is not letting users know what is the underlying value, be it the site default or one set by another activity the current one is based on.

This patch changes the "Select" option by either "Default (XX)" or "Inherit (XX)" depending on the case.

![image](https://github.com/user-attachments/assets/331449ab-30e4-47ba-b14b-9dfd734098f1)
