### PR TITLE
Add escaping of VPL_COMPILATIONFAILED text in default_evaluate

### DIFF
--- a/jail/default_scripts/default_evaluate.sh
+++ b/jail/default_scripts/default_evaluate.sh
@@ -48,7 +48,7 @@ else
 			echo "#!/bin/bash"
 			echo "echo"
 			echo "echo '<|--'"
-			echo "echo '-$VPL_COMPILATIONFAILED'"
+			echo "echo \"-`echo $VPL_COMPILATIONFAILED | sed -e \"s/\\\"/\\\\\\\\\\\"/g\"`\""
 			if [ -f vpl_wexecution ] ; then
 				echo "echo '======================'"
 				echo "echo 'It seems you are trying to test a program with a graphic user interface.'"


### PR DESCRIPTION
The VPL_COMPILATIONFAILED message is not properly escaped in default_evaluate.sh, leading to simple quotes being removed from the message (which can be the case in some translations).  
This fixes the issue.