### PR TITLE
Prevent debug messages from corrupting files download

### DIFF
--- a/views/downloadallsubmissions.php
+++ b/views/downloadallsubmissions.php
@@ -23,6 +23,8 @@
  * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
  */
 
+define( 'NO_DEBUG_DISPLAY', true );
+
 require_once(dirname(__FILE__).'/../../../config.php');
 require_once(dirname(__FILE__).'/../locallib.php');
 require_once(dirname(__FILE__).'/../vpl.class.php');

--- a/views/downloadexecutionfiles.php
+++ b/views/downloadexecutionfiles.php
@@ -23,6 +23,8 @@
  * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
  */
 
+define( 'NO_DEBUG_DISPLAY', true );
+
 require_once(dirname(__FILE__).'/../../../config.php');
 require_once(dirname(__FILE__).'/../locallib.php');
 require_once(dirname(__FILE__).'/../vpl.class.php');

--- a/views/downloadrequiredfiles.php
+++ b/views/downloadrequiredfiles.php
@@ -23,6 +23,8 @@
  * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
  */
 
+define( 'NO_DEBUG_DISPLAY', true );
+
 require_once(dirname(__FILE__).'/../../../config.php');
 require_once(dirname(__FILE__).'/../locallib.php');
 require_once(dirname(__FILE__).'/../vpl.class.php');

--- a/views/downloadsubmission.php
+++ b/views/downloadsubmission.php
@@ -23,6 +23,7 @@
  * @author Juan Carlos Rodríguez-del-Pino <jcrodriguez@dis.ulpgc.es>
  */
 
+define( 'NO_DEBUG_DISPLAY', true );
 
 require_once(dirname(__FILE__).'/../../../config.php');
 require_once(dirname(__FILE__).'/../similarity/watermark.class.php');


### PR DESCRIPTION
When downloading files, if a debug message is displayed, it corrupts the file and download fails.  
This defines the NO_DEBUG_DISPLAY constant in download scripts to send debug info (if any) to error log instead of on the page.  
Note that it should not change anything on production sites where debug display if often disabled by administrators.