### PR TITLE
Fix MOODLE_GROUP_ID environment variable (fixes #226)

### DIFF
--- a/vpl_submission_CE.class.php
+++ b/vpl_submission_CE.class.php
@@ -441,10 +441,10 @@ class mod_vpl_submission_CE extends mod_vpl_submission {
             }
         }
         if ($vpl->is_group_activity() && isset($data->groupid)) {
-            $groupid = $data->groupid;
-            if ($group = $DB->get_record('groups', ['id' => $groupid])) {
-                $info .= vpl_bash_export('MOODLE_GROUP_ID',  $groupid);
-                $info .= vpl_bash_export('MOODLE_GROUP_NAME', $group->name);
+            $group = $vpl->get_usergroup($data->groupid);
+            if ($group) {
+                $info .= vpl_bash_export('MOODLE_GROUP_ID',  $group->id);
+                $info .= vpl_bash_export('MOODLE_GROUP_NAME', format_string($group->name));
             }
         }
         if ($data->type >= self::TEVALUATE) { // If evaluation then add information.


### PR DESCRIPTION
Making use of vpl_usergroup function instead of considering userid as groupid (which was incorrect).
Also added some formatting on group name (as group names can have multilang tags for example).