### PR TITLE
Take into account evaluator files to show concatenated scripts

### DIFF
--- a/views/concatexecfiles.php
+++ b/views/concatexecfiles.php
@@ -84,6 +84,11 @@ $defaultscripts = [
         'vpl_evaluate.sh' => mod_vpl_submission_CE::get_script('evaluate', $pln, $data),
         'vpl_evaluate.cases' => '',
 ];
+if (!empty($vplinstance->evaluator)) {
+    // Override default scripts with evaluator scripts.
+    $evaluator = mod_vpl\plugininfo\vplevaluator::get_evaluator($vplinstance->evaluator);
+    $defaultscripts = array_replace($defaultscripts, array_intersect_key($evaluator->get_execution_files(), $defaultscripts));
+}
 
 $finalscripts = [
         'vpl_run.sh' => [],


### PR DESCRIPTION
Hello,

When setting Evaluator to GIOTES, the concatenated execution files view shows the default vpl_evaluate.sh, and not the one from the GIOTES evaluator.
This is a simple fix for this :-)