### PR TITLE
Listen to tool_mergeusers event to manage submissions merging

### DIFF
--- a/classes/observer/mergeusers.php
+++ b/classes/observer/mergeusers.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Observer for user merging.
+ * @package    mod_vpl
+ * @copyright  2026 Astor Bizard
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_vpl\observer;
+
+use logstore_standard;
+
+/**
+ * Observer definition.
+ * @copyright  2026 Astor Bizard
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mergeusers {
+    /**
+     * Observer called every time an user is merged.
+     * @param \tool_mergeusers\event\user_merged_success $event
+     */
+    public static function user_merged(\tool_mergeusers\event\user_merged_success $event) {
+        global $CFG;
+        if (!is_dir($CFG->dataroot . '/vpl_data')) {
+            return;
+        }
+        $fromid = $event->other['usersinvolved']['fromid'];
+        $toid = $event->other['usersinvolved']['toid'];
+        foreach (array_diff(scandir($CFG->dataroot . '/vpl_data'), [ '.', '..' ]) as $vplid) {
+            $basedir = $CFG->dataroot . '/vpl_data/' . $vplid . '/usersdata';
+            if (is_dir($basedir . '/' . $fromid)) {
+                // Merged user has data in this VPL.
+                foreach (array_diff(scandir($basedir . '/'  . $fromid), [ '.', '..' ]) as $subid) {
+                    if (!is_dir($basedir . '/' . $toid)) {
+                        mkdir($basedir . '/' . $toid);
+                    }
+                    rename($basedir . '/' . $fromid . '/' . $subid, $basedir . '/' . $toid . '/' . $subid);
+                }
+                rmdir($basedir . '/' . $fromid);
+            }
+        }
+    }
+}

--- a/db/events.php
+++ b/db/events.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Event observers declarations.
+ *
+ * @package    mod_vpl
+ * @copyright  2026 Astor Bizard
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$observers = [
+        [
+                'eventname' => '\tool_mergeusers\event\user_merged_success',
+                'callback' => '\mod_vpl\observer\mergeusers::user_merged',
+        ],
+];

--- a/version.php
+++ b/version.php
@@ -29,7 +29,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026042413; // YYYYMMDDHH (year, month, day, hour).
+$plugin->version = 2026042414; // YYYYMMDDHH (year, month, day, hour).
 $plugin->requires = 2022112800; // Moodle 4.1!
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.5.0';


### PR DESCRIPTION
When using the tool_mergeusers plugin (which allows to merge users that end up with duplicate accounts), VPL submissions on file system are not merged.
This commit adds an observer for the merging event, effectively merging the directories on the file system.
Every database change is already managed directly by the tool_mergeusers plugin.